### PR TITLE
versionUpタスク実行時にGradleのエラーが発生する

### DIFF
--- a/sqlapp-gradle-plugin/src/main/groovy/com/sqlapp/gradle/plugins/VersionUpTask.groovy
+++ b/sqlapp-gradle-plugin/src/main/groovy/com/sqlapp/gradle/plugins/VersionUpTask.groovy
@@ -31,6 +31,7 @@ import java.util.List;
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 
@@ -79,6 +80,7 @@ class VersionUpTask extends AbstractDbTask {
 		}
 	}
 
+	@Internal
 	protected VersionUpPojo getVersionUpPojo(){
 		return project.versionUp;
 	}


### PR DESCRIPTION
## エラー内容

versionUpタスク実行時、以下のエラーが出力されました。

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':versionUp' (type 'VersionUpTask').
  - In plugin 'com.sqlapp.db' type 'com.sqlapp.gradle.plugins.VersionUpTask' property 'versionUpPojo' is missing an input or output annotation.
    
    Reason: A property without annotation isn't considered during up-to-date checking.
    
    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.
    
    Please refer to https://docs.gradle.org/7.4.1/userguide/validation_problems.html#missing_annotation for more details about this problem.
```

実行環境は以下となります。
||バージョン番号|
|---|---|
|Gradle|7.4.1|
|Java(Gradleを実行環境)|v11|

Gradle v7以降で発生するように思います。

## 修正方法

出力されている[Gradleのリファレンス](https://docs.gradle.org/7.4.1/userguide/validation_problems.html#missing_annotation)を参考に修正しました。
[インクリメンタルビルド](https://docs.gradle.org/current/userguide/incremental_build.html#sec:task_input_output_side_effects)は不要のタスクに感じましたので、`@Internal`を指定しました。
jar生成時に `updateLicenseMain` タスクが実行された結果、ファイル先頭のCopyrightに修正差分が入りましたが、こちらのPRではとりあえず差分は消しています。

以下の環境で開発しました。

||バージョン番号|
|---|---|
|Eclipse|Eclipse IDE for Java Developers<br>2024-06 (4.32.0)|
|Java(Gradle実行環境)|v11|

## 動作確認

別リポジトリのsqlapp-gradle-exampleを使用して確認しました。
ローカルマシンで`sqlapp-gradle-plugin`のjar生成を行い、生成されたjarを使用して確認しました。
マイグレーション用のSQLを用意し、versionUpタスクによりSQLが正常に実行されることを確認しています。

データベースにはDockerで構築したMySQLを使いました。
https://hub.docker.com/_/mysql
tag: 5.6.51
