### PR TITLE
Fix plugin for gradle8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,6 +134,7 @@ subprojects {
 	}
 
 	task javadocJar(type: Jar) {
+		archiveClassifier = 'javadoc'
 		from javadoc
 		// exclude inner classes
 		//exclude 'org/hoge'

--- a/buildSrc/.gitignore
+++ b/buildSrc/.gitignore
@@ -1,0 +1,7 @@
+/target
+/.settings/
+/.gradle/
+/build/
+/bin/
+/.classpath
+/.project

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 group=com.sqlapp
-version=0.13.0
+version=0.13.1
 junit5MinorVersion=1.0
 
 developerId=satot
 developerName=Tatsuo Satoh
 developerEmail=multisqllib@gmail.com
 developerUrl=
-inceptionYear=2007-2023
+inceptionYear=2007-2024
 url=https://github.com/satotatsu/sqlapp
 
 scmUrl=https://github.com/satotatsu/sqlapp

--- a/sqlapp-command/build.gradle
+++ b/sqlapp-command/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 	//DB
 	//compile 'mysql:mysql-connector-java:5.1.37'
 	testImplementation group: 'mysql', name: 'mysql-connector-java', version: '6.0.5'
-//	testImplementation 'org.mariadb.jdbc:mariadb-java-client:1.3.4'
+	testImplementation 'org.mariadb.jdbc:mariadb-java-client:1.3.4'
 	testImplementation group: 'org.hsqldb', name: 'hsqldb', version: '2.6.1'
 	//JDBC
 	testImplementation group: 'com.zaxxer', name: 'HikariCP', version: '5.0.1'

--- a/sqlapp-command/build.gradle
+++ b/sqlapp-command/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 	//DB
 	//compile 'mysql:mysql-connector-java:5.1.37'
 	testImplementation group: 'mysql', name: 'mysql-connector-java', version: '6.0.5'
-	testImplementation 'org.mariadb.jdbc:mariadb-java-client:1.3.4'
+//	testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.4.1'
 	testImplementation group: 'org.hsqldb', name: 'hsqldb', version: '2.6.1'
 	//JDBC
 	testImplementation group: 'com.zaxxer', name: 'HikariCP', version: '5.0.1'

--- a/sqlapp-command/src/main/java/com/sqlapp/data/db/command/export/ImportDataFromFileCommand.java
+++ b/sqlapp-command/src/main/java/com/sqlapp/data/db/command/export/ImportDataFromFileCommand.java
@@ -249,7 +249,7 @@ public class ImportDataFromFileCommand extends AbstractExportCommand{
 			context.putAll(this.getContext());
 			for(final SqlOperation operation:operations){
 				final SqlNode sqlNode=sqlConverter.parseSql(context, operation.getSqlText());
-				final JdbcHandler jdbcHandler=new JdbcHandler(sqlNode);
+								final JdbcHandler jdbcHandler=new JdbcHandler(sqlNode);
 				jdbcHandler.execute(connection, context);
 				commit(connection, queryCount);
 			}
@@ -353,9 +353,9 @@ public class ImportDataFromFileCommand extends AbstractExportCommand{
 		final ParametersContext context=new ParametersContext();
 		context.putAll(this.getContext());
 		return (r, c, v)->{
-//			if (this.getSqlType().supportRows()){
-//				return v;
-//			}
+			if (this.getSqlType().supportRows()) {
+				return v;
+			}
 			Object originalVal;
 			if (this.getRowValueConverter()!=null) {
 				originalVal=this.getRowValueConverter().apply(r, c, v);

--- a/sqlapp-core-test/.gitignore
+++ b/sqlapp-core-test/.gitignore
@@ -1,0 +1,7 @@
+/target
+/.settings/
+/.gradle/
+/build/
+/bin/
+/.classpath
+/.project

--- a/sqlapp-core/build.gradle
+++ b/sqlapp-core/build.gradle
@@ -78,5 +78,5 @@ dependencies {
 	implementation project(':sqlapp-test')
 	testImplementation project(':sqlapp-test')
 	testImplementation group: 'org.hsqldb', name: 'hsqldb', version: '2.6.0'
-	testImplementation group: 'org.codehaus.groovy', name: 'groovy', version: '3.0.9'
+	testImplementation group: 'org.codehaus.groovy', name: 'groovy', version: '3.0.21'
 }

--- a/sqlapp-gradle-plugin/build.gradle
+++ b/sqlapp-gradle-plugin/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id "com.gradle.plugin-publish" version "0.20.0"
     id "com.github.joschi.licenser" version "0.6.1"
+	id 'groovy-gradle-plugin'
 }
 apply plugin: 'groovy'
 apply plugin: 'com.gradle.plugin-publish'
@@ -80,3 +81,4 @@ pluginBundle {
 	}
 }
 
+generateMetadataFileForMavenJavaPublication.dependsOn validatePlugins

--- a/sqlapp-gradle-plugin/src/main/groovy/com/sqlapp/gradle/plugins/AbstractDbTask.groovy
+++ b/sqlapp-gradle-plugin/src/main/groovy/com/sqlapp/gradle/plugins/AbstractDbTask.groovy
@@ -157,7 +157,7 @@ abstract class AbstractDbTask extends AbstractTask{
 	 */
 	protected DataSource createDataSource(DataSourcePojo obj, boolean debug) {
 		DataSource ds;
-		if (debug) {
+		if (!debug) {
 			ds = new HikariDataSource(getPoolConfiguration(obj));
 		} else{
 			SqlappDataSource sds = new SqlappDataSource(

--- a/sqlapp-gradle-plugin/src/main/groovy/com/sqlapp/gradle/plugins/AbstractTask.groovy
+++ b/sqlapp-gradle-plugin/src/main/groovy/com/sqlapp/gradle/plugins/AbstractTask.groovy
@@ -79,6 +79,7 @@ abstract class AbstractTask extends DefaultTask {
 		setDebug(debug);
 	}
 	
+	@Internal
 	protected boolean isDebug(){
 		return debug;
 	}

--- a/sqlapp-gradle-plugin/src/main/groovy/com/sqlapp/gradle/plugins/SqlExecuteTask.groovy
+++ b/sqlapp-gradle-plugin/src/main/groovy/com/sqlapp/gradle/plugins/SqlExecuteTask.groovy
@@ -61,7 +61,7 @@ class SqlExecuteTask extends AbstractDbTask {
 	String placeholderSuffix='}';
 	@Input
 	@Optional
-	boolean placeholders=false;
+	Boolean placeholders=false;
 
 	@TaskAction
 	def exec() {

--- a/sqlapp-gradle-plugin/src/main/groovy/com/sqlapp/gradle/plugins/VersionUpTask.groovy
+++ b/sqlapp-gradle-plugin/src/main/groovy/com/sqlapp/gradle/plugins/VersionUpTask.groovy
@@ -21,18 +21,19 @@ package com.sqlapp.gradle.plugins
 
 import com.sqlapp.data.db.command.version.VersionUpCommand
 import com.sqlapp.data.db.sql.SqlType
-import com.sqlapp.data.schemas.Table;
+import com.sqlapp.data.schemas.Table
 import com.sqlapp.gradle.plugins.pojo.VersionUpPojo
-import com.sqlapp.util.CommonUtils;
+import com.sqlapp.util.CommonUtils
 
 import java.io.File
-import java.util.List;
+import java.util.List
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
 
 class VersionUpTask extends AbstractDbTask {
 	
@@ -79,6 +80,7 @@ class VersionUpTask extends AbstractDbTask {
 		}
 	}
 
+	@Internal
 	protected VersionUpPojo getVersionUpPojo(){
 		return project.versionUp;
 	}

--- a/sqlapp-test/.gitignore
+++ b/sqlapp-test/.gitignore
@@ -1,0 +1,7 @@
+/target
+/.settings/
+/.gradle/
+/build/
+/bin/
+/.classpath
+/.project


### PR DESCRIPTION
gradle８でプラグインのversionUpタスクを実行したところ以下のエラーが発生したため修正しました。

```
A problem was found with the configuration of task ':versionUp' (type 'VersionUpTask').
  - In plugin 'com.sqlapp.db' type 'com.sqlapp.gradle.plugins.VersionUpTask' property 'versionUpPojo' is missing an input or output annotation.
```

また、他のタスクでも発生しうるエラーをvalidatePluginsタスクでチェックし対応しました。
```
* What went wrong:
Execution failed for task ':sqlapp-gradle-plugin:validatePlugins'.
> Plugin validation failed with 5 problems:
    - Error: Type 'com.sqlapp.gradle.plugins.AbstractTask' property 'debug' has redundant getters: 'getDebug()' and 'isDebug()'.
      
      Reason: Boolean property 'debug' has both an `is` and a `get` getter.

      Possible solutions:
        1. Remove one of the getters.
        2. Annotate one of the getters with @Internal.

      Please refer to https://docs.gradle.org/8.0.2/userguide/validation_problems.html#redundant_getters for more details about this problem.
    - Error: Type 'com.sqlapp.gradle.plugins.SqlExecuteTask' property 'placeholders' of type boolean shouldn't be annotated with @Optional.

      Reason: Properties of primitive type cannot be optional.

      Possible solutions:
        1. Remove the @Optional annotation.
        2. Use the java.lang.Boolean type instead.

      Please refer to https://docs.gradle.org/8.0.2/userguide/validation_problems.html#cannot_use_optional_on_primitive_types for more details about this problem.
    - Error: Type 'com.sqlapp.gradle.plugins.VersionDownSeriesTask' property 'versionUpPojo' is missing an input or output annotation.

      Reason: A property without annotation isn't considered during up-to-date checking.

      Possible solutions:
        1. Add an input or output annotation.
        2. Mark it as @Internal.

      Please refer to https://docs.gradle.org/8.0.2/userguide/validation_problems.html#missing_annotation for more details about this problem.
    - Error: Type 'com.sqlapp.gradle.plugins.VersionDownTask' property 'versionUpPojo' is missing an input or output annotation.

      Reason: A property without annotation isn't considered during up-to-date checking.

      Possible solutions:
        1. Add an input or output annotation.
        2. Mark it as @Internal.

      Please refer to https://docs.gradle.org/8.0.2/userguide/validation_problems.html#missing_annotation for more details about this problem.
    - Error: Type 'com.sqlapp.gradle.plugins.VersionInsertTask' property 'versionUpPojo' is missing an input or output annotation.

      Reason: A property without annotation isn't considered during up-to-date checking.

      Possible solutions:
        1. Add an input or output annotation.
        2. Mark it as @Internal.
```